### PR TITLE
doc: Use the relative links for the doc files in the repo readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,12 +31,11 @@ in [What are the key selling points compared to other knowledge platforms?](#wha
 
 ### Further Reading
 
-- [idea and technical concept](https://sebastianrzk.github.io/Looksyk/idea_and_technical_concept.html)
-- [Install + Run](https://sebastianrzk.github.io/Looksyk/installation.html)
-- [Migrate Your Existing Logseq Graph](https://sebastianrzk.github.io/Looksyk/migration_from_logseq.html)
-- [Configuration and Usage](https://sebastianrzk.github.io/Looksyk/usage.html)
-- [Development Guide and Contribution Guidelines](https://sebastianrzk.github.io/Looksyk/development_and_contribution.html)
-- [Changelog](https://sebastianrzk.github.io/Looksyk/changelog.html)
+- [idea and technical concept](docs/idea_and_technical_concept.md)
+- [Install + Run](docs/installation.md)
+- [Migrate Your Existing Logseq Graph](docs/migration_from_logseq.md)
+- [Configuration and Usage](docs/usage.md)
+- [Changelog](docs/changelog.md)
 
 ## Introduction
 
@@ -110,6 +109,10 @@ Install it and try it out! [Installation Guide](https://sebastianrzk.github.io/L
 * Sync with other devices. Please use other tools
   like [Nextcloud](https://nextcloud.com/install/), [git](https://git-scm.com/)
   or [OneDrive](https://www.microsoft.com/de-de/microsoft-365/onedrive/online-cloud-storage) to sync your knowledge base
+
+## Development
+
+- [Development Guide and Contribution Guidelines](docs/development_and_contribution.md)
 
 ## License
 


### PR DESCRIPTION
This means it'll work within editors like vscode without jumping out to the web browser.

Also moved development link to own section as I missed it first time, assumed it wouldn't be under "further reading" so had skimmed past it.

fixes issue #31