### PR TITLE
feat: Dark/light mode

### DIFF
--- a/backend/src/io/http/design/endpoints.rs
+++ b/backend/src/io/http/design/endpoints.rs
@@ -1,6 +1,7 @@
 use actix_web::http::header::ContentType;
 use actix_web::web::Data;
 use actix_web::{get, HttpResponse};
+use serde_json::json;
 
 use crate::state::application_state::AppState;
 
@@ -26,4 +27,12 @@ pub async fn get_css_theme(app_state: Data<AppState>) -> HttpResponse {
     HttpResponse::Ok()
         .insert_header(ContentType(mime::TEXT_CSS))
         .body(css_text)
+}
+
+#[get("/api/appearance")]
+pub async fn get_appearance(app_state: Data<AppState>) -> HttpResponse {
+    let config = app_state.g_config.lock().unwrap();
+    let appearance = config.appearance.as_ref().unwrap_or(&"dark".to_string()).clone();
+    drop(config);
+    HttpResponse::Ok().json(json!({ "appearance": appearance }))
 }

--- a/backend/src/looksyk/data/config/init/graph.rs
+++ b/backend/src/looksyk/data/config/init/graph.rs
@@ -29,6 +29,7 @@ fn init_empty_graph(data_root_location: &GraphRootLocation) {
                 foreground_color: "white".to_string(),
                 primary_shading: "rgba(255, 255, 255, 0.1)".to_string(),
             },
+            appearance: Some("dark".to_string()),
             title: Some("No Graph Title".to_string()),
         },
     );

--- a/backend/src/looksyk/data/config/runtime_graph_configuration.rs
+++ b/backend/src/looksyk/data/config/runtime_graph_configuration.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct Config {
     pub favourites: Vec<Favourite>,
     pub design: Design,
+    pub appearance: Option<String>,
     pub title: Option<String>,
 }
 
@@ -43,6 +44,7 @@ pub mod builder {
         Config {
             design: empty_design(),
             favourites: vec![favourite_str(fav)],
+            appearance: Some("dark".to_string()),
             title: None,
         }
     }

--- a/backend/src/looksyk/favourite.rs
+++ b/backend/src/looksyk/favourite.rs
@@ -19,6 +19,7 @@ pub fn add_favourite(simple_page_name: SimplePageName, config: &Config) -> Confi
     Config {
         favourites: new_favourites,
         design: config.design.clone(),
+        appearance: config.appearance.clone(),
         title: config.title.clone(),
     }
 }
@@ -33,6 +34,7 @@ pub fn set_favourites(new_favourites: Vec<SimplePageName>, config: &Config) -> C
     Config {
         favourites: result,
         design: config.design.clone(),
+        appearance: config.appearance.clone(),
         title: config.title.clone(),
     }
 }
@@ -50,6 +52,7 @@ pub fn remove_favourite(simple_page_name: SimplePageName, config: &Config) -> Co
     Config {
         favourites: new_favourites,
         design: config.design.clone(),
+        appearance: config.appearance.clone(),
         title: config.title.clone(),
     }
 }
@@ -84,6 +87,7 @@ mod tests {
         let config: Config = Config {
             favourites: vec![],
             design: empty_design(),
+            appearance: Some("dark".to_string()),
             title: None,
         };
 
@@ -128,6 +132,7 @@ mod tests {
                 },
             ],
             design: empty_design(),
+            appearance: Some("dark".to_string()),
             title: None,
         };
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> std::io::Result<()> {
             .service(media::endpoints::upload_file)
             .service(media::endpoints::compute_asset_suggestion)
             .service(design::endpoints::get_css_theme)
+            .service(design::endpoints::get_appearance)
             .service(metainfo::endpoints::get_metainfo)
             .service(metainfo::endpoints::get_title)
             .service(r#static::endpoints::fav)

--- a/frontend/looksyk/angular.json
+++ b/frontend/looksyk/angular.json
@@ -92,7 +92,8 @@
             ],
             "styles": [
               "@angular/material/prebuilt-themes/purple-green.css",
-              "src/styles.css"
+              "src/styles.css",
+              "src/assets/fonts/highlightjs.11.9.min.css"
             ],
             "scripts": [
               "../node_modules/marked/marked.min.js"

--- a/frontend/looksyk/src/app/services/appearance.service.ts
+++ b/frontend/looksyk/src/app/services/appearance.service.ts
@@ -1,0 +1,35 @@
+import { inject, Injectable, Inject, DOCUMENT } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, lastValueFrom, map } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AppearanceService {
+  private httpClient: HttpClient = inject(HttpClient);
+  private appearance = new BehaviorSubject<'light' | 'dark'>('dark');
+  public appearance$ = this.appearance.asObservable();
+
+  constructor(@Inject(DOCUMENT) private document: Document) {
+    // Subscribe to appearance changes and update HTML data attribute
+    this.appearance$.subscribe(appearance => {
+      this.document.documentElement.setAttribute('data-theme', appearance);
+    });
+  }
+
+  public fetchAppearance(): void {
+    lastValueFrom(
+      this.httpClient.get<AppearanceDto>('/api/appearance').pipe(
+        map(x => x.appearance as 'light' | 'dark')
+      )
+    ).then(x => this.appearance.next(x));
+  }
+
+  public getCurrentAppearance(): 'light' | 'dark' {
+    return this.appearance.value;
+  }
+}
+
+interface AppearanceDto {
+  appearance: string;
+}

--- a/frontend/looksyk/src/index.html
+++ b/frontend/looksyk/src/index.html
@@ -10,10 +10,8 @@
   <link rel="icon" type="image/x-icon" href="assets/fav.png">
   <link href="/assets/fonts/font_eb_garamond.css" rel="stylesheet">
   <link href="/assets/fonts/material-icons.css" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/fonts/highlightjs.11.9.min.css">
-  <link rel="stylesheet" href="/assets/fonts/highlightjs.11.10.min.dark.css">
 </head>
-<body data-theme="dark">
+<body>
   <app-root></app-root>
 </body>
 </html>


### PR DESCRIPTION
Hi, this adds conceptual support for dark/light mode theming incl. highlight-js.

**Configuration**
`config.json`
```json
/* ... */
  "appearance": "light",
/* ... */
```

**Usage**
`user-theme.css`
```css
html[data-theme='light'] {
	/* ... */
}
html[data-theme='light'] {
	/* ... */
}
```