### PR TITLE
Move icon to left of header (UX)

### DIFF
--- a/frontend/looksyk/src/app/pages/journal-overview/journal-overview.component.html
+++ b/frontend/looksyk/src/app/pages/journal-overview/journal-overview.component.html
@@ -11,10 +11,10 @@
   }
 
   <mat-divider vertical="true"></mat-divider>
-  <h1 class="header-text">Journal Overview</h1>
   <button mat-mini-fab>
     <mat-icon routerLink="/journal">post</mat-icon>
   </button>
+  <h1 class="header-text">Journal Overview</h1>
 </div>
 <mat-divider></mat-divider>
 <div class="global-content">
@@ -22,4 +22,3 @@
     <app-display-markdown-page [page]="p"></app-display-markdown-page>
   }
 </div>
-

--- a/frontend/looksyk/src/app/pages/journal/journal.component.html
+++ b/frontend/looksyk/src/app/pages/journal/journal.component.html
@@ -11,10 +11,10 @@
   }
 
   <mat-divider vertical="true"></mat-divider>
-  <h1 class="header-text">Journal</h1>
   <button mat-mini-fab>
     <mat-icon routerLink="/special-page/journal-overview">calendar_month</mat-icon>
   </button>
+  <h1 class="header-text">Journal</h1>
 </div>
 <mat-divider></mat-divider>
 <div class="global-content">


### PR DESCRIPTION
Hi, this moves the journal icon (switch between views) to the left of the header.

Rationale: Icon does not move due to different header length, can immediately be clicked again.